### PR TITLE
feat: add s3 failovers + some other fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,5 +51,3 @@ body = obj["Body"].read()
 Import the default logger and set its level to DEBUG
 
 `logging.getLogger().setLevel(logging.DEBUG)`
-
-

--- a/README.md
+++ b/README.md
@@ -28,12 +28,13 @@ export BOLT_CUSTOM_DOMAIN="example.com"
 
 **There are two ways to expose Bolt's region/preferred availability zone to the SDK:**
 
-1. If running on an EC2 instance the SDK will by default use that instance's region and zone ID
-2. With the ENV variables: `AWS_REGION` and `AWS_ZONE_ID`.
+If running on an EC2 instance, the SDK will use the instance's region and availability zone id, unless overriden with environment variables: `BOLT_REGION` and `BOLT_AZ_ID`
+
 ```bash
-export AWS_REGION='<region>'
-export AWS_ZONE_ID='<az-id>'
+export BOLT_REGION='<region>'
+export BOLT_AZ_ID='<az-id>'
 ```
+
 ## Example usage
 
 ```python

--- a/bolt/__init__.py
+++ b/bolt/__init__.py
@@ -10,6 +10,7 @@
 # language governing permissions and limitations under the License.
 
 import json
+import sys
 
 from collections import defaultdict
 from os import environ as _environ
@@ -37,10 +38,11 @@ class Session(_Session):
             try:
                 region = get_region()
             except Exception as e:
-                pass
+                print("BOLT_REGION environment variable is not set, and could not be automatically determined.")
+                sys.exit(1)
+
         custom_domain = _environ.get('BOLT_CUSTOM_DOMAIN')
         service_url = _environ.get('BOLT_URL')
-        bolt_hostname = _environ.get('BOLT_HOSTNAME')
         hostname = None
 
         if custom_domain is not None and region is not None:
@@ -130,5 +132,3 @@ def resource(*args, **kwargs):
     See :py:meth:`boto3.session.Session.resource`.
     """
     return _get_default_session().resource(*args, **kwargs)
-
-

--- a/bolt/__init__.py
+++ b/bolt/__init__.py
@@ -44,7 +44,7 @@ class Session(_Session):
         hostname = None
 
         if custom_domain is not None and region is not None:
-            scheme = 'https' 
+            scheme = 'https'
             service_url = "quicksilver.{}.{}".format(region, custom_domain)
             hostname = "bolt.{}.{}".format(region, custom_domain)
         elif service_url is not None:

--- a/bolt/__init__.py
+++ b/bolt/__init__.py
@@ -60,11 +60,12 @@ class Session(_Session):
             raise ValueError(
                 'Bolt settings could not be found.\nPlease expose 1. BOLT_URL or 2. BOLT_CUSTOM_DOMAIN')
 
-        az_id = None
-        try:
-            az_id = get_availability_zone_id()
-        except Exception as e:
-            pass
+        az_id = _environ.get('BOLT_AZ_ID')
+        if az_id is None:
+          try:
+              az_id = get_availability_zone_id()
+          except Exception as e:
+              pass
 
         self.bolt_router = BoltRouter(scheme, service_url, hostname, region, az_id, update_interval=30)
         self.events.register_last('before-send.s3', self.bolt_router.send)

--- a/bolt/bolt_router.py
+++ b/bolt/bolt_router.py
@@ -255,10 +255,10 @@ class BoltRouter:
         print("path without bucket: ", path_without_bucket)
 
         # virtual hosted style
-        # new_url =  "https://{}.s3.{}.amazonaws.com/{}".format(source_bucket, self._region, path_without_bucket)
+        new_url =  "https://{}.s3.{}.amazonaws.com/{}".format(source_bucket, self._region, path_without_bucket)
 
         # pathstyle
-        new_url = "https://s3.{}.amazonaws.com{}".format(self._region, path)
+        # new_url = "https://s3.{}.amazonaws.com{}".format(self._region, path)
 
         print("new url: ", new_url)
         failover_request = AWSRequest(
@@ -305,5 +305,5 @@ class BoltRouter:
                     # use random choice for load balancing
                     return choice(self._bolt_endpoints[endpoints])
         # if we reach this point, no endpoints are available
-        return "localhost:8443"
-        # raise UnknownEndpointError(service_name='bolt', region_name=self._az_id)
+        # return "localhost:8443"
+        raise UnknownEndpointError(service_name='bolt', region_name=self._az_id)

--- a/bolt/bolt_router.py
+++ b/bolt/bolt_router.py
@@ -234,11 +234,11 @@ class BoltRouter:
         try: 
           bolt_response =  BoltSession(self._hostname, verify=ssl_verify).send(prepared_request)
           if 400 <= bolt_response.status_code < 500:
-              logger.debug("failing over to aws, bolt response code was 4xx", extra={"status_code": bolt_response.status_code})
+              logger.info"bolt request failed - 4xx - falling back to aws", extra={"status_code": bolt_response.status_code})
               return URLLib3Session().send(incoming_request)
           return bolt_response
         except Exception as e:
-          logger.debug("failing over to aws cause of exception", extra={"exception": e})
+          logger.info("bolt request failed - exception - falling back to aws", extra={"exception": e})
           return URLLib3Session().send(incoming_request)
 
     def _get_endpoints(self):

--- a/bolt/bolt_router.py
+++ b/bolt/bolt_router.py
@@ -276,11 +276,11 @@ class BoltRouter:
         try: 
           bolt_response =  BoltSession(self._hostname).send(prepared_request)
           if 400 <= bolt_response.status_code < 500:
-              logger.info("bolt request failed - 4xx - falling back to aws", extra={"status_code": bolt_response.status_code})
+              logger.debug("bolt request failed - 4xx - falling back to aws", extra={"status_code": bolt_response.status_code})
               return URLLib3Session().send(incoming_request)
           return bolt_response
         except Exception as e:
-          logger.info("bolt request failed - exception - falling back to aws", extra={"exception": e})
+          logger.debug("bolt request failed - exception - falling back to aws", extra={"exception": e})
           return URLLib3Session().send(incoming_request)
 
     def _get_endpoints(self):

--- a/bolt/bolt_router.py
+++ b/bolt/bolt_router.py
@@ -5,12 +5,14 @@ from random import choice
 from urllib3 import PoolManager
 from threading import Lock
 
+import copy
 import random
 import sys 
 import sched
 import time
 import datetime
 import string
+import requests
 from functools import wraps
 from threading import Thread
 from urlparse import urlsplit
@@ -97,7 +99,7 @@ class BoltSession(URLLib3Session):
         return super(BoltSession, self)._get_pool_manager_kwargs(**extra_kwargs)
 
 
-    def send(self, request, failover_request):
+    def send(self, request):
         # start: do bolt request
         request.headers['Host'] = self._bolt_hostname
         for key in request.headers.keys():
@@ -106,19 +108,7 @@ class BoltSession(URLLib3Session):
             request.headers[key] = request.headers[key]
 
         request.headers["x-set-response-status-code"] = "405"
-        bolt_response = super(BoltSession, self).send(request)
-
-        if bolt_response.status_code >= 200 and bolt_response.status_code < 300:
-            return bolt_response
-        # end: do bolt request
-
-        # start: do failover request
-        if 400 <= bolt_response.status_code < 500:
-            print("failing over to aws")
-            s3_response = super(BoltSession, self).send(failover_request)
-            print("response code: ", s3_response.status_code)
-            return s3_response
-        # end: do failover request
+        return super(BoltSession, self).send(request)
 
         
 def roundTime(dt=None, dateDelta=datetime.timedelta(minutes=1)):
@@ -216,6 +206,9 @@ class BoltRouter:
     def send(self, *args, **kwargs):
         # Dispatches to the configured Bolt scheme and host.
         prepared_request = kwargs['request']
+        # print("incoming request")
+        # print(prepared_request)
+        incoming_request = copy.deepcopy(prepared_request)
         _, _, path, query, fragment = urlsplit(prepared_request.url)
         host = self._select_endpoint(prepared_request.method)
         if self._scheme == "http":
@@ -227,6 +220,7 @@ class BoltRouter:
         source_bucket = path.split('/')[1]
 
         # Construct the HEAD request that would be sent out by Bolt for authentication
+        # print("making a head request")
         request = AWSRequest(
           method='HEAD',
           url='https://s3.{}.amazonaws.com/{}/{}/auth'.format(self._region,source_bucket, self._prefix),
@@ -241,48 +235,66 @@ class BoltRouter:
 
         self._auth.add_auth(request)
 
+        # print("done making head request")
+
         for key in ["X-Amz-Date", "Authorization", "X-Amz-Security-Token", "X-Amz-Content-Sha256"]:
           if request.headers.get(key):
             prepared_request.headers[key] = request.headers[key]
         prepared_request.headers['X-Bolt-Auth-Prefix'] = self._prefix
 
-        print("prepared request body: ", str(prepared_request.body))
-        print("prepared request url: ", prepared_request.url)
-        print("prepared request headers: ", prepared_request.headers)
+        # print("prepared request body: ", str(prepared_request.body))
+        # print("prepared request url: ", prepared_request.url)
+        # print("prepared request headers: ", prepared_request.headers)
 
-        print("path: ", path)
+        # print("path: ", path)
         path_without_bucket = "".join(path.split('/')[2:])
-        print("path without bucket: ", path_without_bucket)
+        # print("path without bucket: ", path_without_bucket)
+
+        # raw boto uses past style
+        # DEBUG:botocore.utils:Updating URI from https://s3.amazonaws.com/km-us-west-2/kote.txt to https://s3.us-west-2.amazonaws.com/km-us-west-2/kote.txt
 
         # virtual hosted style
-        new_url =  "https://{}.s3.{}.amazonaws.com/{}".format(source_bucket, self._region, path_without_bucket)
+        # new_url =  "https://{}.s3.{}.amazonaws.com/{}".format(source_bucket, self._region, path_without_bucket)
 
         # pathstyle
         # new_url = "https://s3.{}.amazonaws.com{}".format(self._region, path)
+        # new_url = "https://google.com"
+        # print("new url: ", new_url)
 
-        print("new url: ", new_url)
-        failover_request = AWSRequest(
-            method=prepared_request.method,
-            url=new_url,
-            data=prepared_request.body,
-            params=None,
-            headers=None
-        )
-        self._auth.add_auth(failover_request)
+        # resp = requests.get(new_url)
+        # print(resp.status_code)
+        # print(resp.text)
+
+        # failover_request = AWSRequest(
+        #     method=prepared_request.method,
+        #     url=new_url,
+        #     data="kote-from-code", # prepared_request.body,
+        #     params=None,
+        #     headers=None
+        # )
+        # self._auth.add_auth(failover_request)
         
-        prepared_failover_request = failover_request.prepare()
-        prepared_failover_request.headers["Host"] = "https://{}.s3.{}.amazonaws.com".format(source_bucket, self._region)
+        # prepared_failover_request = failover_request.prepare()
+        # prepared_failover_request.headers["Host"] = "https://{}.s3.{}.amazonaws.com".format(source_bucket, self._region)
+        # prepared_failover_request.headers["Host"] = "https://s3.{}.amazonaws.com".format(self._region)
 
-        print("prepared failover request body: ", str(prepared_failover_request.body))
-        print("prepared failover request url: ", prepared_failover_request.url)
-        print("prepared failover request headers: ", prepared_failover_request.headers)
+        # print("prepared failover request body: ", str(prepared_failover_request.body))
+        # print("prepared failover request url: ", prepared_failover_request.url)
+        # print("prepared failover request headers: ", prepared_failover_request.headers)
         
 
         # send this request with our custom session options
         # if an AWSResponse is returned directly from a `before-send` event handler function, 
         # botocore will use that as the response without making its own request.
-        ssl_verify = True  # disable if running locally
-        return BoltSession(self._hostname, verify=False).send(prepared_request, prepared_failover_request)
+        try: 
+          bolt_response =  BoltSession(self._hostname, verify=ssl_verify).send(prepared_request)
+          if 400 <= bolt_response.status_code < 500:
+              logger.debug("failing over to aws, bolt response code was 4xx", extra={"status_code": bolt_response.status_code})
+              return URLLib3Session().send(incoming_request)
+          return bolt_response
+        except Exception as e:
+          logger.debug("failing over to aws cause of exception", extra={"exception": e})
+          return URLLib3Session().send(incoming_request)
 
     def _get_endpoints(self):
         try:
@@ -305,5 +317,4 @@ class BoltRouter:
                     # use random choice for load balancing
                     return choice(self._bolt_endpoints[endpoints])
         # if we reach this point, no endpoints are available
-        # return "localhost:8443"
         raise UnknownEndpointError(service_name='bolt', region_name=self._az_id)

--- a/bolt/bolt_router.py
+++ b/bolt/bolt_router.py
@@ -282,7 +282,7 @@ class BoltRouter:
         # if an AWSResponse is returned directly from a `before-send` event handler function, 
         # botocore will use that as the response without making its own request.
         ssl_verify = True  # disable if running locally
-        return BoltSession(self._hostname, ssl_verify=False).send(prepared_request, prepared_failover_request)
+        return BoltSession(self._hostname, verify=False).send(prepared_request, prepared_failover_request)
 
     def _get_endpoints(self):
         try:
@@ -305,5 +305,5 @@ class BoltRouter:
                     # use random choice for load balancing
                     return choice(self._bolt_endpoints[endpoints])
         # if we reach this point, no endpoints are available
-        # return "localhost:8443"
-        raise UnknownEndpointError(service_name='bolt', region_name=self._az_id)
+        return "localhost:8443"
+        # raise UnknownEndpointError(service_name='bolt', region_name=self._az_id)

--- a/bolt/bolt_router.py
+++ b/bolt/bolt_router.py
@@ -234,7 +234,7 @@ class BoltRouter:
         try: 
           bolt_response =  BoltSession(self._hostname, verify=ssl_verify).send(prepared_request)
           if 400 <= bolt_response.status_code < 500:
-              logger.info"bolt request failed - 4xx - falling back to aws", extra={"status_code": bolt_response.status_code})
+              logger.info("bolt request failed - 4xx - falling back to aws", extra={"status_code": bolt_response.status_code})
               return URLLib3Session().send(incoming_request)
           return bolt_response
         except Exception as e:

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with io.open("README.md", "r", encoding="utf-8") as fh:
 setup(
     name='bolt-sdk-py2',
     packages=setuptools.find_packages(),
-    version='1.0.1',
+    version='1.0.2',
     description='Bolt Python SDK',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Add a behavior to failover to s3 when request to Bolt / Crunch fails for whatever reason.

* Create a deep copy of the incoming request
* Upon failure, use a default botocore urrlib3 session to make the incoming request w/o modifications
* Fix fetching of ec2 instance region and az id - need to obtain a token
* Exit if region not specified and cannot be fetched from the metadata api
* Try to read the az id from env var, then try to fetch from metadata api - ok to skip here as everything will still work
* Global http pool - not sure why we were creating a pool inside a function each time?
* Update readme to be consistent with code

**Testing**
* tested against local http server w/ edits to make it work (no quicksilver etc) + fault injection ✅ 
* tested against a live Bolt cluster w/ fault injection ✅ 