### PR TITLE
feat: quicksilver bolt endpoint fetch improvements

### DIFF
--- a/bolt/__init__.py
+++ b/bolt/__init__.py
@@ -10,7 +10,7 @@
 # language governing permissions and limitations under the License.
 
 import sys
-from os import environ as _environ
+from os import environ
 
 from boto3 import Session as _Session
 from botocore.config import Config as _Config
@@ -27,7 +27,7 @@ class Session(_Session):
         super(Session, self).__init__()
 
         # Load all of the possibly configuration settings
-        region = _environ.get("BOLT_REGION")
+        region = environ.get("BOLT_REGION")
         if region is None:
             try:
                 region = get_region()
@@ -37,8 +37,8 @@ class Session(_Session):
                 )
                 sys.exit(1)
 
-        custom_domain = _environ.get("BOLT_CUSTOM_DOMAIN")
-        service_url = _environ.get("BOLT_URL")
+        custom_domain = environ.get("BOLT_CUSTOM_DOMAIN")
+        service_url = environ.get("BOLT_URL")
         hostname = None
 
         if custom_domain is not None and region is not None:
@@ -61,7 +61,7 @@ class Session(_Session):
                 "Bolt settings could not be found.\nPlease expose 1. BOLT_URL or 2. BOLT_CUSTOM_DOMAIN"
             )
 
-        az_id = _environ.get("BOLT_AZ_ID")
+        az_id = environ.get("BOLT_AZ_ID")
         if az_id is None:
             try:
                 az_id = get_availability_zone_id()

--- a/bolt/__init__.py
+++ b/bolt/__init__.py
@@ -12,8 +12,8 @@
 import sys
 from os import environ
 
-from boto3 import Session as _Session
-from botocore.config import Config as _Config
+from boto3 import Session as Boto3Session
+from botocore.config import Config as Boto3Config
 from urlparse import urlsplit
 
 from .bolt_router import BoltRouter, get_availability_zone_id, get_region
@@ -22,7 +22,7 @@ BOLT_ENDPOINT_UPDATE_INTERVAL = 10
 
 
 # Override Session Class
-class Session(_Session):
+class Session(Boto3Session):
     def __init__(self):
         super(Session, self).__init__()
 
@@ -87,7 +87,7 @@ class Session(_Session):
 
     def _merge_bolt_config(self, client_config):
         # Override client config
-        bolt_config = _Config(
+        bolt_config = Boto3Config(
             s3={"addressing_style": "path", "signature_version": "s3v4"}
         )
         if client_config is not None:

--- a/bolt/__init__.py
+++ b/bolt/__init__.py
@@ -13,7 +13,7 @@ import sys
 from os import environ
 
 from boto3 import Session as Boto3Session
-from botocore.config import Config as Boto3Config
+from botocore.config import Config as BotoCoreConfig
 from urlparse import urlsplit
 
 from .bolt_router import BoltRouter, get_availability_zone_id, get_region
@@ -87,7 +87,7 @@ class Session(Boto3Session):
 
     def _merge_bolt_config(self, client_config):
         # Override client config
-        bolt_config = Boto3Config(
+        bolt_config = BotoCoreConfig(
             s3={"addressing_style": "path", "signature_version": "s3v4"}
         )
         if client_config is not None:

--- a/bolt/__init__.py
+++ b/bolt/__init__.py
@@ -18,6 +18,8 @@ from urlparse import urlsplit
 
 from .bolt_router import BoltRouter, get_availability_zone_id, get_region
 
+BOLT_ENDPOINT_UPDATE_INTERVAL = 10
+
 
 # Override Session Class
 class Session(_Session):
@@ -67,7 +69,12 @@ class Session(_Session):
                 pass
 
         self.bolt_router = BoltRouter(
-            scheme, service_url, hostname, region, az_id, update_interval=30
+            scheme=scheme,
+            quicksilver_api_base_url=service_url,
+            hostname=hostname,
+            region=region,
+            az_id=az_id,
+            update_interval=BOLT_ENDPOINT_UPDATE_INTERVAL,
         )
         self.events.register_last("before-send.s3", self.bolt_router.send)
 

--- a/bolt/__init__.py
+++ b/bolt/__init__.py
@@ -9,23 +9,14 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-import json
 import sys
-
-from collections import defaultdict
 from os import environ as _environ
-from random import choice
-from threading import Lock
-import urllib3
-from boto3 import Session as _Session
-from botocore.auth import SigV4Auth as _SigV4Auth
-from botocore.awsrequest import AWSRequest as _AWSRequest
-from botocore.config import Config as _Config
-from botocore.exceptions import UnknownEndpointError
-from urlparse import urlsplit
-from urlparse import urlunsplit
 
-from .bolt_router import BoltRouter, get_region, get_availability_zone_id
+from boto3 import Session as _Session
+from botocore.config import Config as _Config
+from urlparse import urlsplit
+
+from .bolt_router import BoltRouter, get_availability_zone_id, get_region
 
 
 # Override Session Class

--- a/bolt/bolt_router.py
+++ b/bolt/bolt_router.py
@@ -86,14 +86,6 @@ def get_availability_zone_id():
         )
 
 
-def _default_get(url):
-    try:
-        resp = http_pool.request('GET', url, retries=2)
-        return resp.data.decode('utf-8')
-    except Exception as e:
-        raise e
-
-
 def async_function(func):
     @wraps(func)
     def async_func(*args, **kwargs):

--- a/bolt/bolt_router.py
+++ b/bolt/bolt_router.py
@@ -1,29 +1,25 @@
-from collections import defaultdict
+import copy
+import datetime
 import json
+import random
+import sched
+import string
+import sys
+import time
+from collections import defaultdict
+from functools import wraps
 from os import environ
 from random import choice
-from threading import Lock
+from threading import Lock, Thread
 
-import copy
-import random
-import sys
-import sched
-import time
-import datetime
-import string
-import requests
 import urllib3
-from urllib3.util.retry import Retry
-from functools import wraps
-from threading import Thread
-from urlparse import urlsplit
-from urlparse import urlunsplit
-
-from botocore.auth import SigV4Auth, SIGV4_TIMESTAMP, logger
+from botocore.auth import SIGV4_TIMESTAMP, SigV4Auth, logger
 from botocore.awsrequest import AWSRequest
 from botocore.exceptions import UnknownEndpointError
-from botocore.session import get_session
 from botocore.httpsession import URLLib3Session
+from botocore.session import get_session
+from urllib3.util.retry import Retry
+from urlparse import urlsplit, urlunsplit
 
 EC2_INSTANCE_METADATA_API_BASE_URL = "http://169.254.169.254"
 

--- a/bolt/bolt_router.py
+++ b/bolt/bolt_router.py
@@ -235,17 +235,33 @@ class BoltRouter:
     )
 
     def __init__(
-        self, scheme, service_url, hostname, region, az_id, update_interval=-1
+        self,
+        scheme,
+        quicksilver_api_base_url,
+        hostname,
+        region,
+        az_id,
+        update_interval=-1,
     ):
         # The scheme (parsed at bootstrap from the AWS config).
         self._scheme = scheme
         # The service discovery host (parsed at bootstrap from the AWS config).
-        self._service_url = service_url
+        self._quicksilver_api_base_url = quicksilver_api_base_url
         # the hostname to use for SSL validation when connecting directly to Bolt IPs
         self._hostname = hostname
         # Availability zone ID to use (may be none)
         self._az_id = az_id
         self._region = region
+
+        if self._az_id is None:
+            # None obj formats as "None" into the string so let's not include it if it's None
+            self._quicksilver_url = '{}/services/bolt'.format(
+                self._quicksilver_api_base_url
+            )
+        else:
+            self._quicksilver_url = '{}/services/bolt?az={}'.format(
+                self._quicksilver_api_base_url, self._az_id
+            )
 
         # Map of Bolt endpoints to use for connections, and mutex protecting it
         self._bolt_endpoints = defaultdict(list)
@@ -342,13 +358,12 @@ class BoltRouter:
 
     def _get_endpoints(self):
         try:
-            service_url = '{}/services/bolt?az={}'.format(
-                self._service_url, self._az_id
-            )
-            resp = _default_get(service_url)
-            endpoint_map = json.loads(resp)
-            with self._mutex:
-                self._bolt_endpoints = defaultdict(list, endpoint_map)
+            response = http_pool.request('GET', self._quicksilver_url)
+            if response.status == 200:
+                response_data = response.data.decode('utf-8')
+                endpoint_map = json.loads(response_data)
+                with self._mutex:
+                    self._bolt_endpoints = defaultdict(list, endpoint_map)
         except Exception as e:
             raise e
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with io.open("README.md", "r", encoding="utf-8") as fh:
 setup(
     name='bolt-sdk-py2',
     packages=setuptools.find_packages(),
-    version='1.0.2',
+    version='1.0.3',
     description='Bolt Python SDK',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
### Changes
* fetch bolt endpoinds from quicksilver every 10 seconds
* update the endpoints map only if quicksilver returns 200, otherwise we'll just try again
* clean up and organize imports
* better quicksilver url construction to avoid `?az=None` strings
* remove the `_default_get` function and use the shared http_pool manager

### Testing
Tested using the `test.py` script that does object upload, bucket list, object download against a Bolt cluster.