### PR TITLE
add timeout in the ec2 metadata request - so we do not hang for long

### DIFF
--- a/bolt/bolt_router.py
+++ b/bolt/bolt_router.py
@@ -27,7 +27,8 @@ http_pool = urllib3.PoolManager(
     retries=Retry(
         total=5,  # Total number of retries
         backoff_factor=0.1,  # Time to sleep between retries (0.1s, 0.2s, 0.4s, ...)
-    )
+    ),
+    timeout=urllib3.Timeout(total=1.0)
 )
 
 


### PR DESCRIPTION
```
Python 2.7.18 (default, Oct 19 2023, 21:17:03)
[GCC 7.3.1 20180712 (Red Hat 7.3.1-17)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import bolt
>>> c = bolt.client("s3")
BOLT_REGION environment variable is not set, and could not be automatically determined.
```